### PR TITLE
Run command on SIGINT

### DIFF
--- a/src/support.coffee
+++ b/src/support.coffee
@@ -26,7 +26,7 @@ match = (val,values...) -> values.indexOf(val) >= 0
   console.error termColorWrap '0;38;5;246', "- #{msg}"
 
 termColorWrap = (code, str) -> termColor(code) + str + termColor()
-termColor = (code = '') -> '\033' + '[' + code + 'm'
+termColor = (code = '') -> '\u001b' + '[' + code + 'm'
 
 # ---
 

--- a/src/wach-cli.coffee
+++ b/src/wach-cli.coffee
@@ -50,13 +50,38 @@ watch = require './wach'
     log.info "running: #{commandWithPathSubsitution}"
     log.info ""
 
+    runCommand commandWithPathSubsitution
+
+  runCommand = (command) ->
     # Run command in subshell
-    child = spawn 'sh', ['-c', commandWithPathSubsitution ]
+    child = spawn 'sh', ['-c', command ]
     commandRunning = yes
     child.stdout.pipe process.stdout
     child.stderr.pipe process.stderr
     child.on 'exit', (code) ->
       commandRunning = no
+
+  process.stdin.on 'end', ->
+    log.info ""
+    log.info "Recieved CTRL+D. Killing self."
+    log.info ""
+
+    process.kill()
+
+  # resume STDIN so we can watch for EOF/CTRL+D
+  process.stdin.resume()
+
+  process.on 'SIGINT', ->
+    # get rid of the '^C'
+    process.stdout.clearLine()
+    process.stdout.cursorTo 0
+
+    log.info ""
+    log.info "Recieved SIGINT. Running command: #{args.command}"
+    log.info "To quit, use CTRL+D or CTRL+\\."
+    log.info ""
+
+    runCommand args.command
 
 # ---
 

--- a/src/wach-cli.coffee
+++ b/src/wach-cli.coffee
@@ -1,4 +1,8 @@
+fs = require 'fs'
 path = require 'path'
+# support < node 0.8
+fs.existsSync = path.existsSync unless typeof fs.existsSync is 'function'
+
 spawn = require('child_process').spawn
 minimatch = require 'minimatch'
 
@@ -34,7 +38,7 @@ watch = require './wach'
     return if commandRunning
 
     # do nothing for deletes
-    return unless path.existsSync changedPath
+    return unless fs.existsSync changedPath
     # do nothing for ignored paths
     return if (args.only.length   isnt 0) and (not matchesGlobs changedPath, args.only)
     return if (args.except.length isnt 0) and (    matchesGlobs changedPath, args.except)


### PR DESCRIPTION
This patch uses the SIGINT signal to have wach manually run the command without filesystem changes happening. This means I don't have to manually run the command in a different terminal when I miss changes (for whatever reason).

If this approach looks good, I will update `wachs-cli` and compile the JS.

There are also a few random changes for new node/coffee.
