### PR TITLE
Use minimatch `dot` option so that changes in directories that start with a dot don't cause a rebuild

### DIFF
--- a/lib/support.js
+++ b/lib/support.js
@@ -91,7 +91,9 @@
       _results = [];
       for (_i = 0, _len = globs.length; _i < _len; _i++) {
         glob = globs[_i];
-        if (minimatch(path, glob)) {
+        if (minimatch(path, glob, {
+          dot: true
+        })) {
           _results.push(match);
         }
       }

--- a/src/support.coffee
+++ b/src/support.coffee
@@ -33,7 +33,7 @@ termColor = (code = '') -> '\x1B' + '[' + code + 'm'
 minimatch = require 'minimatch'
 
 @matchesGlobs = (path, globs) ->
-  matches = (match for glob in globs when minimatch path, glob)
+  matches = (match for glob in globs when minimatch path, glob, dot: true)
   matches.length isnt 0
 
 # ---


### PR DESCRIPTION
I currently have to use this long exclude string to exclude dirs that start with a `.`:

```
.*,.idea/*,.idea/**/*,dashboard/**/*,dashboard/.idea/*,dashboard/.idea/**/*,terminal/**/*,terminal/.idea/*,terminal/.idea/**/*,.git/*,.git/**/*,bin/**/*
```

This is because minimatch [doesn't match dirs that start with a dot](https://github.com/isaacs/minimatch#dot) unless you specify the `dot` option. With this change this becomes: `.*,dashboard/**/*,terminal/**/*,.git/*,.git/**/*,bin/**/*`

I understand if you don't want to merge this.
